### PR TITLE
chore: fail build (RUN false) for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+# Intentionally fail the build
+RUN false
+


### PR DESCRIPTION
Intentional change to trigger a failed build pipeline run for export/testing.

Made with [Cursor](https://cursor.com)