### PR TITLE
chore: fail EC (vulnerable base) for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+# Use old Alpine base with known CVEs to trigger EC vulnerability check failure
+FROM alpine:3.10
 
 COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
-
+#!/bin/sh
+set -e
 echo "hello world"


### PR DESCRIPTION
Uses alpine:3.10 base image to trigger enterprise-contract vulnerability/policy failure for export/testing.

Made with [Cursor](https://cursor.com)