### PR TITLE
chore: fail EC - no LICENSE in image, deprecated label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 COPY entrypoint.sh /
+# Intentionally do NOT copy LICENSE to /licenses/ - EC may require license in image
+# Use deprecated "License" label (replacement: org.opencontainers.image.licenses) to trigger labels.deprecated_labels
+LABEL License="MIT"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Intentional changes to trigger EC failure for testing/export:

1. **Missing LICENSE in image**: Added a LICENSE file to the repo but do **not** copy it to `/licenses/` in the image. Policies that require license info in the image will fail.

2. **Deprecated label**: Use the deprecated `License` OCI label (replacement: `org.opencontainers.image.licenses`) to trigger `labels.deprecated_labels` if the Konflux EC policy has that rule data.

Made with [Cursor](https://cursor.com)